### PR TITLE
chore: Match variable names used on the tutorial

### DIFF
--- a/src/composables/usePhotoGallery.ts
+++ b/src/composables/usePhotoGallery.ts
@@ -87,13 +87,13 @@ export function usePhotoGallery() {
   };
 
   const takePhoto = async () => {
-    const cameraPhoto = await Camera.getPhoto({
+    const photo = await Camera.getPhoto({
       resultType: CameraResultType.Uri,
       source: CameraSource.Camera,
       quality: 100,
     });
     const fileName = new Date().getTime() + '.jpeg';
-    const savedFileImage = await savePicture(cameraPhoto, fileName);
+    const savedFileImage = await savePicture(photo, fileName);
 
     photos.value = [savedFileImage, ...photos.value];
   };


### PR DESCRIPTION
The tutorial changed some variable names, so better use the same names in the app to make it easier to follow/compare.