### PR TITLE
refactor(composables): update to use base64FromPath

### DIFF
--- a/src/composables/usePhotoGallery.ts
+++ b/src/composables/usePhotoGallery.ts
@@ -14,15 +14,22 @@ export const usePhotoGallery = () => {
   const PHOTO_STORAGE = 'photos';
   const photos = ref<UserPhoto[]>([]);
 
-  const convertBlobToBase64 = (blob: Blob): Promise<string> =>
-    new Promise((resolve, reject) => {
+  const base64FromPath = async (path: string): Promise<string> => {
+    const response = await fetch(path);
+    const blob = await response.blob();
+    return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onerror = reject;
       reader.onload = () => {
-        resolve(reader.result as string);
+        if (typeof reader.result === 'string') {
+          resolve(reader.result);
+        } else {
+          reject('method did not return a string');
+        }
       };
       reader.readAsDataURL(blob);
     });
+  };
 
   const cachePhotos = () => {
     Preferences.set({
@@ -59,10 +66,7 @@ export const usePhotoGallery = () => {
       });
       base64Data = typeof file.data === 'string' ? file.data : await file.data.text();
     } else {
-      // Fetch the photo, read as a blob, then convert to base64 format
-      const response = await fetch(photo.webPath!);
-      const blob = await response.blob();
-      base64Data = (await convertBlobToBase64(blob)) as string;
+      base64Data = await base64FromPath(photo.webPath!);
     }
     const savedFile = await Filesystem.writeFile({
       path: fileName,


### PR DESCRIPTION
resolves #18

## Description
This updates the photo saving functionality to use the same structure as the [React tutorial](https://github.com/ionic-team/tutorial-photo-gallery-react/blob/1fb8eba40bbef1933550c649241f61512bea7e75/src/hooks/usePhotoGallery.ts#L112-L127) by using a `base64FromPath` method instead of `convertBlobToBase64`.  

Related PR: https://github.com/ionic-team/ionic-docs/pull/4659